### PR TITLE
Swift styling and Documentation refactor

### DIFF
--- a/Example/ODScrollView/AppDelegate.swift
+++ b/Example/ODScrollView/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        return true
+        true
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/Example/ODScrollView/MainViewController.swift
+++ b/Example/ODScrollView/MainViewController.swift
@@ -53,11 +53,11 @@ extension MainViewController: ODScrollViewDelegate {
     }
     
     func adjustmentDirection(for textInput: UITextInput, inside scrollView: ODScrollView) -> AdjustmentDirection {
-        .Bottom
+        .bottom
     }
     
     func adjustmentOption(for scrollView: ODScrollView) -> AdjustmentOption {
-        .Always
+        .always
     }
     
     func hideKeyboardByTappingToView(for scrollView: ODScrollView) -> UIView? {

--- a/Example/ODScrollView/TextCursorTrackingViewController.swift
+++ b/Example/ODScrollView/TextCursorTrackingViewController.swift
@@ -57,11 +57,11 @@ extension TextCursorTrackingViewController: ODScrollViewDelegate {
     }
     
     func adjustmentDirection(for textInput: UITextInput, inside scrollView: ODScrollView) -> AdjustmentDirection {
-        .Bottom
+        .bottom
     }
     
     func adjustmentOption(for scrollView: ODScrollView) -> AdjustmentOption {
-        .Always
+        .always
     }
     
     func hideKeyboardByTappingToView(for scrollView: ODScrollView) -> UIView? {

--- a/Example/Tests/ODScrollViewAdjustmentCalculatorTests.swift
+++ b/Example/Tests/ODScrollViewAdjustmentCalculatorTests.swift
@@ -33,7 +33,8 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
   
         var inputViewRectGlobal: CGRect = CGRect.zero
         
-        init(position ODScrollViewAndKeyboardPositionSetting: ODScrollViewAndKeyboardRelationSettingEnum? = nil, inputFrame inputViewFrameSetting: InputViewFrameSettingEnum? = nil) {
+        init(position ODScrollViewAndKeyboardPositionSetting: ODScrollViewAndKeyboardRelationSettingEnum? = nil,
+             inputFrame inputViewFrameSetting: InputViewFrameSettingEnum? = nil) {
             
             setupUIElements()
             switch (ODScrollViewAndKeyboardPositionSetting, inputViewFrameSetting) {
@@ -68,7 +69,6 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
             default:
                 assertionFailure("Something went wrong")
-                
             }
         }
         
@@ -97,24 +97,15 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
             inputViewRectGlobal = CGRect(x: 0, y: 0, width: 100, height: inputNotFittedHeight)
         }
     }
-        
 
-
-    override func setUp() {
-        
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
 
     // MARK: - isScrollViewAndKeyboardOverlapping
     func testScrollViewAndKeyboardOverlapping() {
  
         let setting = ODScrollViewCalculatorSetting(position: .overlapping)
         
-        let res = ODScrollViewAdjustmentCalculator.isScrollViewAndKeyboardOverlapping(keyboardMinYGlobal: setting.keyboardMinYGlobal, scrollViewMaxYGlobal: setting.scrollViewMaxYGlobal)
+        let res = ODScrollViewAdjustmentCalculator.isScrollViewAndKeyboardOverlapping(keyboardMinYGlobal: setting.keyboardMinYGlobal,
+                                                                                      scrollViewMaxYGlobal: setting.scrollViewMaxYGlobal)
         
         XCTAssertEqual(res, true)
 
@@ -124,7 +115,8 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
         
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping)
         
-        let res = ODScrollViewAdjustmentCalculator.isScrollViewAndKeyboardOverlapping(keyboardMinYGlobal: setting.keyboardMinYGlobal, scrollViewMaxYGlobal: setting.scrollViewMaxYGlobal)
+        let res = ODScrollViewAdjustmentCalculator.isScrollViewAndKeyboardOverlapping(keyboardMinYGlobal: setting.keyboardMinYGlobal,
+                                                                                      scrollViewMaxYGlobal: setting.scrollViewMaxYGlobal)
         
         XCTAssertEqual(res, false)
 
@@ -133,7 +125,7 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
     // MARK: - isAdjustmentEnable
     func testIsAdjustmentEnableAlways() {
         
-        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnable(adjustmentOption: .Always)
+        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnabled(adjustmentOption: .always)
         
         XCTAssertEqual(res, true)
     }
@@ -143,7 +135,9 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
         var setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .fit)
         setting.inputViewRectGlobal = CGRect(x: 0, y: 0, width: 100, height: setting.keyboardMinYGlobal + 1)
         
-        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnable(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY, keyboardMinYGlobal: setting.keyboardMinYGlobal, adjustmentOption: .IfNeeded)
+        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnabled(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY,
+                                                                       keyboardMinYGlobal: setting.keyboardMinYGlobal,
+                                                                       adjustmentOption: .ifNeeded)
         
         XCTAssertEqual(res, true)
     }
@@ -153,15 +147,20 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
         var setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .fit)
         setting.inputViewRectGlobal = CGRect(x: 0, y: 0, width: 100, height: setting.keyboardMinYGlobal - 1)
         
-        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnable(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY, keyboardMinYGlobal: setting.keyboardMinYGlobal, adjustmentOption: .IfNeeded)
+        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnabled(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY,
+                                                                       keyboardMinYGlobal: setting.keyboardMinYGlobal,
+                                                                       adjustmentOption: .ifNeeded)
         
         XCTAssertEqual(res, false)
     }
+
     func testIsAdjustmentEnableIfNeededOverlappingAndNotFit() {
         
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnable(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY, keyboardMinYGlobal: setting.keyboardMinYGlobal, adjustmentOption: .IfNeeded)
+        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnabled(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY,
+                                                                       keyboardMinYGlobal: setting.keyboardMinYGlobal,
+                                                                       adjustmentOption: .ifNeeded)
         
         XCTAssertEqual(res, true)
     }
@@ -170,14 +169,16 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
         
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping)
 
-        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnable(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY, keyboardMinYGlobal: setting.keyboardMinYGlobal, adjustmentOption: .IfNeeded)
+        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnabled(inputViewMaxYGlobal: setting.inputViewRectGlobal.maxY,
+                                                                       keyboardMinYGlobal: setting.keyboardMinYGlobal,
+                                                                       adjustmentOption: .ifNeeded)
         
         XCTAssertEqual(res, false)
     }
     
     func testIsAdjustmentEnableIfNeededMissingParameter() {
                 
-        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnable(adjustmentOption: .IfNeeded)
+        let res = ODScrollViewAdjustmentCalculator.isAdjustmentEnabled(adjustmentOption: .ifNeeded)
         
         XCTAssertEqual(res, false)
     }
@@ -187,7 +188,9 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.isInputViewFitsRemainingArea(inputViewHeight: setting.inputViewRectGlobal.height, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
+        let res = ODScrollViewAdjustmentCalculator.isInputViewFitsRemainingArea(inputViewHeight: setting.inputViewRectGlobal.height,
+                                                                                remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                                remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
         
         XCTAssertEqual(res, true)
     }
@@ -196,7 +199,9 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.isInputViewFitsRemainingArea(inputViewHeight: setting.inputViewRectGlobal.height, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
+        let res = ODScrollViewAdjustmentCalculator.isInputViewFitsRemainingArea(inputViewHeight: setting.inputViewRectGlobal.height,
+                                                                                remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                                remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
         
         XCTAssertEqual(res, false)
     }
@@ -208,7 +213,8 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
 
         let cursorMaxYGlobal = setting.inputViewRectGlobal.maxY
         
-        let res = ODScrollViewAdjustmentCalculator.isTextInputCursorTrackingEnable(cursorMaxYGlobal: cursorMaxYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
+        let res = ODScrollViewAdjustmentCalculator.isTextInputCursorTrackingEnabled(cursorMaxYGlobal: cursorMaxYGlobal,
+                                                                                    remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
         
         XCTAssertEqual(res, true)
     }
@@ -218,7 +224,8 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
         let setting = ODScrollViewCalculatorSetting(inputFrame: .fit)
         let cursorMaxYGlobal = setting.inputViewRectGlobal.maxY
 
-        let res = ODScrollViewAdjustmentCalculator.isTextInputCursorTrackingEnable(cursorMaxYGlobal: cursorMaxYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
+        let res = ODScrollViewAdjustmentCalculator.isTextInputCursorTrackingEnabled(cursorMaxYGlobal: cursorMaxYGlobal,
+                                                                                    remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal)
         
         XCTAssertEqual(res, false)
     }
@@ -229,7 +236,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Top, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .top,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
                 
         let correctResult = setting.inputViewRectGlobal.minY - setting.scrollViewMinYGlobal - setting.keyboardTopMarginFromAdjustedView
         XCTAssertEqual(res, correctResult)
@@ -239,7 +250,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
             
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Top, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .top,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
                 
         XCTAssertEqual(res, 0)
     }
@@ -248,7 +263,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping, inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Top, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .top,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         let correctResult = setting.inputViewRectGlobal.minY - setting.scrollViewMinYGlobal - setting.keyboardTopMarginFromAdjustedView
         XCTAssertEqual(res, correctResult)
@@ -258,7 +277,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping, inputFrame: .notFit)
 
-         let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Top, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+         let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .top,
+                                                                           inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                           remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                           remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                           keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         XCTAssertEqual(res, 0)
     }
     
@@ -267,7 +290,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Center, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .center,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         let remainingAreaMidYGlobal = setting.scrollViewMinYGlobal + (setting.scrollViewMaxYGlobal - setting.scrollViewMinYGlobal) / 2
         
@@ -279,7 +306,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
             
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Center, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .center,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         XCTAssertEqual(res, 0)
     }
@@ -288,7 +319,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping, inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Center, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .center,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         let remainingAreaMidYGlobal = setting.scrollViewMinYGlobal + (setting.scrollViewMaxYGlobal - setting.scrollViewMinYGlobal) / 2
         let correctResult = setting.inputViewRectGlobal.midY - remainingAreaMidYGlobal
@@ -299,7 +334,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping, inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Top, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .top,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         XCTAssertEqual(res, 0)
     }
@@ -309,7 +348,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Bottom, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .bottom,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         let correctResult = setting.inputViewRectGlobal.maxY - setting.scrollViewMaxYGlobal + setting.keyboardTopMarginFromAdjustedView
         XCTAssertEqual(res, correctResult)
@@ -319,8 +362,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
             
         let setting = ODScrollViewCalculatorSetting(position: .overlapping, inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Bottom, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
-        
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .bottom,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
                 
         XCTAssertEqual(res, 0)
     }
@@ -329,7 +375,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping, inputFrame: .fit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Bottom, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .bottom,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
         
         let correctResult = setting.inputViewRectGlobal.maxY - setting.scrollViewMaxYGlobal + setting.keyboardTopMarginFromAdjustedView
         XCTAssertEqual(res, correctResult)
@@ -339,8 +389,11 @@ class ODScrollViewAdjustmentCalculatorTests: XCTestCase {
                 
         let setting = ODScrollViewCalculatorSetting(position: .notOverlapping, inputFrame: .notFit)
 
-        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .Top, inputViewRectGlobal: setting.inputViewRectGlobal, remainingAreaMinYGlobal: setting.scrollViewMinYGlobal, remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal, keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
-        
+        let res = ODScrollViewAdjustmentCalculator.calculateContentOffset(adjustmentDirection: .top,
+                                                                          inputViewRectGlobal: setting.inputViewRectGlobal,
+                                                                          remainingAreaMinYGlobal: setting.scrollViewMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: setting.scrollViewMaxYGlobal,
+                                                                          keyboardTopMarginFromAdjustedView: setting.keyboardTopMarginFromAdjustedView)
                 
         XCTAssertEqual(res, 0)
     }

--- a/ODScrollView/Classes/AdjustmentDirection.swift
+++ b/ODScrollView/Classes/AdjustmentDirection.swift
@@ -8,8 +8,15 @@
 
 import Foundation
 
+/// Default value is `.bottom`
 public enum AdjustmentDirection {
-    case Top
-    case Center
-    case Bottom // Default
+
+    ///
+    case top
+
+    ///
+    case center
+
+    ///
+    case bottom
 }

--- a/ODScrollView/Classes/AdjustmentOption.swift
+++ b/ODScrollView/Classes/AdjustmentOption.swift
@@ -8,15 +8,12 @@
 
 import Foundation
 
+/// Default value is `.always`
 public enum AdjustmentOption {
-    
-    /**
-     ODScrollView always adjusts the UITextInput -firstResponder- which is placed anywhere in the ODScrollView.
-     */
-    case Always // Default
-    
-    /***
-     ODScrollView only adjusts the UITextInput  -firstResponder- if it overlaps with the keyboard.
-     */
-    case IfNeeded
+
+    /// ODScrollView always adjusts the UITextInput -firstResponder- which is placed anywhere in the ODScrollView.
+    case always
+
+    /// ODScrollView only adjusts the UITextInput  -firstResponder- if it overlaps with the keyboard.
+    case ifNeeded
 }

--- a/ODScrollView/Classes/KeyboardObserver.swift
+++ b/ODScrollView/Classes/KeyboardObserver.swift
@@ -15,37 +15,38 @@ protocol KeyboardObserver: class {
 extension KeyboardObserver {
   
     func addKeyboardObservers() {
+        NotificationCenter.addObserver(with: UIResponder.keyboardDidShowNotification) { [weak self] notification in
+            guard
+                let self = self,
+                let keyboardFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            else { return }
+            self.keyboardDidShow(with: keyboardFrame.height)
+        }
 
-        NotificationCenter.default.addObserver(
-            forName: UIResponder.keyboardDidShowNotification,
-            object: nil,
-            queue: nil,
-            using: { [weak self] notification in
-                guard let self = self else {return}
-                guard let keyboardFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
-                    return
-                }
-
-                self.keyboardDidShow(with: keyboardFrame.height)
-        })
-        
-        NotificationCenter.default.addObserver(
-            forName: UIResponder.keyboardDidHideNotification,
-            object: nil,
-            queue: nil,
-            using: { [weak self] _ in
-                self?.keyboardDidHide()
-        })
+        NotificationCenter.addObserver(with: UIResponder.keyboardDidHideNotification) { [weak self] _ in
+            self?.keyboardDidHide()
+        }
     }
     
     func removeKeyboardObservers() {
+        NotificationCenter.removeObserver(with: UIResponder.keyboardDidHideNotification, observer: self)
+        NotificationCenter.removeObserver(with: UIResponder.keyboardDidShowNotification, observer: self)
+    }
+}
+        
+private extension NotificationCenter {
+    static func addObserver(with notificationName: NSNotification.Name, using block: @escaping (Notification) -> Void) {
+        NotificationCenter.default.addObserver(
+            forName: notificationName,
+            object: nil,
+            queue: nil,
+            using: block)
+    }
+
+    static func removeObserver(with notificationName: NSNotification.Name, observer: KeyboardObserver) {
         NotificationCenter.default.removeObserver(
-            self,
-            name: UIResponder.keyboardDidHideNotification,
-            object: nil)
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIResponder.keyboardDidShowNotification,
+            observer,
+            name: notificationName,
             object: nil)
     }
 }

--- a/ODScrollView/Classes/ODScrollView.swift
+++ b/ODScrollView/Classes/ODScrollView.swift
@@ -72,7 +72,7 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
     func keyboardDidHide() {
         resetAdjustedView()
         resetToInitialSettings()
-        self.odScrollViewDelegate?.keyboardDidHide(by: self)
+        odScrollViewDelegate?.keyboardDidHide(by: self)
         
         isKeyboardHidden = true
     }
@@ -129,7 +129,7 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
     }
     
     private func setupRenderer() {
-        self.renderer = ODScrollViewRenderer(self)
+        renderer = ODScrollViewRenderer(self)
     }
     
     private func setupAdjustmentDirectionSetting() {

--- a/ODScrollView/Classes/ODScrollView.swift
+++ b/ODScrollView/Classes/ODScrollView.swift
@@ -21,17 +21,15 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
             setupRenderer()
         }
     }
-        
-    /**
-     ODScrollView's contentView have to be registered on ViewDidLoad()
-     */
+
+    /// ODScrollView's contentView have to be registered on ViewDidLoad()
     public func registerContentView(_ contentView: UIView) {
         scrollContentView = contentView
     }
     
-    // Keyboard States
-    private var isKeyboardHidden: Bool = true // keyboardDidShow can be called while the keyboard is already open. isKeyboardHidden is needed to be aware of such cases.
-    
+    /// Keyboard States
+    /// keyboardDidShow can be called while the keyboard is already open. isKeyboardHidden is needed to be aware of such cases.
+    private var isKeyboardHidden: Bool = true
     
     func keyboardDidShow(with keyboardHeight: CGFloat) {
         
@@ -46,7 +44,9 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
 
         // Check whether firstResponder UITextInput object is inside scrollContentView or not.
         
-        // We have to add observer to default notification center with name UIResponder.keyboardDidShowNotification to detect keyboard opening. But this observer can be notified any keyboard opening not just UITextInput views inside ODScrollView. This is how keyboard notifications works. So we are checking that the notification is came from ODScrollView or not every time when observer is notified.
+        /// We have to add observer to default notification center with name UIResponder.keyboardDidShowNotification to detect keyboard opening. But this observer can be notified any keyboard
+        /// opening not just UITextInput views inside ODScrollView. This is how keyboard notifications works. So we are checking that the notification is came from ODScrollView
+        /// or not every time when observer is notified.
         if renderer.isFirstResponderInputViewExists(inside: contentView) {
           
             setupAdjustmentDirectionSetting()
@@ -79,9 +79,9 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
      Adjusts the ODScrollView when the cursor overlaps with keyboard while typing in multiline UITextInput. This method must be called by UITextInput functions that is fired while typing.
                 
             func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-                    _ODScrollView.trackTextInputCursor(for textView)
-                    return true
-                }
+                _ODScrollView.trackTextInputCursor(for textView)
+                return true
+            }
 
      ## IMPORTANT:
      This feature is not going to work unless textView is subView of _ODScrollView
@@ -120,7 +120,7 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
             let hideTapGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIInputViewController.dismissKeyboard))
             hideKeyboardView.addGestureRecognizer(hideTapGesture)
         } else {
-            print("WARNING: UIView was not provided by hideKeyboardByTappingToView func of ODScrollViewDelegate. isResettingAdjustmentEnabled feature cannot be used.")
+            assertionFailure("WARNING: UIView was not provided by hideKeyboardByTappingToView func of ODScrollViewDelegate. isResettingAdjustmentEnabled feature cannot be used.")
         }
         
         addKeyboardObservers()
@@ -131,14 +131,13 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
     }
     
     private func setupAdjustmentDirectionSetting() {
-        guard let odScrollViewDelegate = odScrollViewDelegate else { return }
+        guard
+            let odScrollViewDelegate = odScrollViewDelegate,
+            let currentTextInput = renderer?.firstResponderUITextInputView as? UITextInput
+        else { return }
 
-        if let currentTextInput = renderer?.firstResponderUITextInputView as? UITextInput {
-            ODScrollViewOptions.adjustmentDirection = odScrollViewDelegate.adjustmentDirection(for: currentTextInput, inside: self)
-            
-            ODScrollViewOptions.adjustmentMargin = odScrollViewDelegate.adjustmentMargin(for: currentTextInput, inside: self)
-            
-            ODScrollViewOptions.adjustmentEnabled = odScrollViewDelegate.adjustmentEnabled(for: currentTextInput, inside: self)
-        }
+        ODScrollViewOptions.adjustmentDirection = odScrollViewDelegate.adjustmentDirection(for: currentTextInput, inside: self)
+        ODScrollViewOptions.adjustmentMargin = odScrollViewDelegate.adjustmentMargin(for: currentTextInput, inside: self)
+        ODScrollViewOptions.adjustmentEnabled = odScrollViewDelegate.adjustmentEnabled(for: currentTextInput, inside: self)
     }
 }

--- a/ODScrollView/Classes/ODScrollView.swift
+++ b/ODScrollView/Classes/ODScrollView.swift
@@ -35,12 +35,14 @@ public final class ODScrollView: UIScrollView, KeyboardObserver {
         
         odScrollViewDelegate?.keyboardDidShow(by: self)
 
-        guard let contentView = scrollContentView else {
+        guard
+            let contentView = scrollContentView,
+            let renderer = renderer
+        else {
             assertionFailure("contentView is nil! You have to call ODScrollView.registerContentView")
             return
         }
         
-        guard let renderer = renderer else { return }
 
         // Check whether firstResponder UITextInput object is inside scrollContentView or not.
         

--- a/ODScrollView/Classes/ODScrollViewAdjustmentCalculator.swift
+++ b/ODScrollView/Classes/ODScrollViewAdjustmentCalculator.swift
@@ -13,7 +13,7 @@ final class ODScrollViewAdjustmentCalculator {
     
     static func isScrollViewAndKeyboardOverlapping(keyboardMinYGlobal: CGFloat,
                                                    scrollViewMaxYGlobal: CGFloat) -> Bool {
-        return scrollViewMaxYGlobal > keyboardMinYGlobal
+        scrollViewMaxYGlobal > keyboardMinYGlobal
     }
     
     static func isAdjustmentEnabled(inputViewMaxYGlobal: CGFloat? = nil,
@@ -24,9 +24,10 @@ final class ODScrollViewAdjustmentCalculator {
         case .always:
             return true
         case .ifNeeded:
-            guard let inputViewMaxYGlobal = inputViewMaxYGlobal, let keyboardMinYGlobal = keyboardMinYGlobal else {
-                return false
-            }
+            guard
+                let inputViewMaxYGlobal = inputViewMaxYGlobal,
+                let keyboardMinYGlobal = keyboardMinYGlobal
+            else { return false }
 
             // Adjustment is enabled if the inputView stays under keyboard.
             return inputViewMaxYGlobal >= keyboardMinYGlobal ? true : false
@@ -36,7 +37,7 @@ final class ODScrollViewAdjustmentCalculator {
     static func isInputViewFitsRemainingArea(inputViewHeight: CGFloat,
                                              remainingAreaMinYGlobal: CGFloat,
                                              remainingAreaMaxYGlobal: CGFloat) -> Bool {
-        return remainingAreaMaxYGlobal - remainingAreaMinYGlobal >= inputViewHeight
+        remainingAreaMaxYGlobal - remainingAreaMinYGlobal >= inputViewHeight
     }
     
     static func calculateContentOffset(adjustmentDirection: AdjustmentDirection,
@@ -45,7 +46,9 @@ final class ODScrollViewAdjustmentCalculator {
                                        remainingAreaMaxYGlobal: CGFloat,
                                        keyboardTopMarginFromAdjustedView: CGFloat) -> CGFloat {
         
-        if !ODScrollViewAdjustmentCalculator.isInputViewFitsRemainingArea(inputViewHeight: inputViewRectGlobal.height, remainingAreaMinYGlobal: remainingAreaMinYGlobal, remainingAreaMaxYGlobal: remainingAreaMaxYGlobal) {
+        if !ODScrollViewAdjustmentCalculator.isInputViewFitsRemainingArea(inputViewHeight: inputViewRectGlobal.height,
+                                                                          remainingAreaMinYGlobal: remainingAreaMinYGlobal,
+                                                                          remainingAreaMaxYGlobal: remainingAreaMaxYGlobal) {
             return 0
         }
         
@@ -62,6 +65,6 @@ final class ODScrollViewAdjustmentCalculator {
     
     static func isTextInputCursorTrackingEnabled(cursorMaxYGlobal: CGFloat,
                                                  remainingAreaMaxYGlobal: CGFloat) -> Bool {
-        return cursorMaxYGlobal > remainingAreaMaxYGlobal
+        cursorMaxYGlobal > remainingAreaMaxYGlobal
     }
 }

--- a/ODScrollView/Classes/ODScrollViewAdjustmentCalculator.swift
+++ b/ODScrollView/Classes/ODScrollViewAdjustmentCalculator.swift
@@ -16,16 +16,20 @@ final class ODScrollViewAdjustmentCalculator {
         return scrollViewMaxYGlobal > keyboardMinYGlobal
     }
     
-    static func isAdjustmentEnable(inputViewMaxYGlobal: CGFloat? = nil, keyboardMinYGlobal: CGFloat? = nil, adjustmentOption: AdjustmentOption) -> Bool {
+    static func isAdjustmentEnabled(inputViewMaxYGlobal: CGFloat? = nil,
+                                    keyboardMinYGlobal: CGFloat? = nil,
+                                    adjustmentOption: AdjustmentOption) -> Bool {
+
         switch adjustmentOption {
-        case .Always:
+        case .always:
             return true
-        case .IfNeeded:
+        case .ifNeeded:
             guard let inputViewMaxYGlobal = inputViewMaxYGlobal, let keyboardMinYGlobal = keyboardMinYGlobal else {
                 return false
             }
 
-            return inputViewMaxYGlobal >= keyboardMinYGlobal ? true : false // Adjustment is enabled if the inputView stays under keyboard.
+            // Adjustment is enabled if the inputView stays under keyboard.
+            return inputViewMaxYGlobal >= keyboardMinYGlobal ? true : false
         }
     }
     
@@ -46,18 +50,18 @@ final class ODScrollViewAdjustmentCalculator {
         }
         
         switch adjustmentDirection {
-        case .Top:
+        case .top:
             return inputViewRectGlobal.minY - remainingAreaMinYGlobal - keyboardTopMarginFromAdjustedView
-        case .Center:
+        case .center:
             let remainingAreaMidYGlobal = remainingAreaMinYGlobal + (remainingAreaMaxYGlobal - remainingAreaMinYGlobal) / 2
             return inputViewRectGlobal.midY - remainingAreaMidYGlobal
-        case .Bottom:
+        case .bottom:
             return inputViewRectGlobal.maxY - remainingAreaMaxYGlobal + keyboardTopMarginFromAdjustedView
         }
     }
     
-    static func isTextInputCursorTrackingEnable(cursorMaxYGlobal: CGFloat,
-                                                remainingAreaMaxYGlobal: CGFloat ) -> Bool {
+    static func isTextInputCursorTrackingEnabled(cursorMaxYGlobal: CGFloat,
+                                                 remainingAreaMaxYGlobal: CGFloat) -> Bool {
         return cursorMaxYGlobal > remainingAreaMaxYGlobal
     }
 }

--- a/ODScrollView/Classes/ODScrollViewDelegate.swift
+++ b/ODScrollView/Classes/ODScrollViewDelegate.swift
@@ -11,89 +11,117 @@ import UIKit
 public protocol ODScrollViewDelegate: AnyObject {
     
     // MARK:- State Notifiers
-    
-    /**
-     Notifies when the keyboard showed.
-     */
+
+    ///
+    /// Notifies when the keyboard showed.
+    ///
+    /// - Parameter scrollView: TODO
     func keyboardDidShow(by scrollView: ODScrollView)
-    
-    /**
-     Notifies before the UIScrollView adjustment.
-     */
+
+
+    ///
+    /// Notifies before the UIScrollView adjustment.
+    ///
+    /// - Parameter scrollView: TODO
     func scrollAdjustmentWillBegin(by scrollView: ODScrollView)
     
-    /**
-     Notifies after the UIScrollView adjustment.
-     */
+
+    ///
+    /// Notifies after the UIScrollView adjustment.
+    ///
+    /// - Parameter scrollView: TODO
     func scrollAdjustmentDidEnd(by scrollView: ODScrollView)
-    
-    /**
-     Notifies when the keyboard hid.
-     */
+
+
+    ///
+    /// Notifies when the keyboard hid.
+    ///
+    /// - Parameter scrollView: TODO
     func keyboardDidHide(by scrollView: ODScrollView)
     
     
     // MARK:- Adjustment Settings
-    /**
-     Adjusts the distance between keyboard and firstResponder view.
-     
-            if let textField = textInput as? UITextField, textField == self.UITextField_inside_contentView {
-                return 20
-            } else {
-                return 40
-            }
-     */
+
+    ///
+    /// Adjusts the distance between keyboard and firstResponder view.
+    ///
+    /// ```
+    ///     if let textField = textInput as? UITextField, textField == self.UITextField_inside_contentView {
+    ///         return 20
+    ///     } else {
+    ///         return 40
+    ///     }
+    /// ```
+    /// - Parameters:
+    ///   - textInput: TODO
+    ///   - scrollView: TODO
     func adjustmentMargin(for textInput: UITextInput, inside scrollView: ODScrollView) -> CGFloat
-    
-    /**
-     Specifies adjustment direction for each UITextInput. It means that  some of UITextInputs inside ODScrollView can be adjusted to the bottom, while others can be adjusted to center or top.
-                   
-            if let textView = textInput as? UITextView, textView == self.YOURTEXTVIEW {
-                return .Bottom
-            } else {
-                return .Center
-            }
-     */
+
+
+    ///
+    /// Specifies adjustment direction for each UITextInput. It means that  some of UITextInputs inside ODScrollView can be adjusted to the bottom, while others can be adjusted to center or top.
+    ///
+    /// ```
+    ///     if let textView = textInput as? UITextView, textView == self.YOURTEXTVIEW {
+    ///         return .Bottom
+    ///     } else {
+    ///         return .Center
+    ///     }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - textInput: TODO
+    ///   - scrollView: TODO
     func adjustmentDirection(for textInput: UITextInput, inside scrollView: ODScrollView) -> AdjustmentDirection
-    
-    /**
-     Adjustment can be enabled/disabled for each UITextInput seperately. True by default.
-     */
+
+
+    ///
+    /// Adjustment can be enabled/disabled for each UITextInput seperately. True by default.
+    ///
+    /// - Parameters:
+    ///   - textInput: TODO
+    ///   - scrollView: TODO
     func adjustmentEnabled(for textInput: UITextInput, inside scrollView: ODScrollView) -> Bool
 
-    /**
-     There 2 types of adjustment option: Always and IfNeeded
-        
-        - Always : ODScrollView always adjusts the UITextInput which is placed anywhere in the ODScrollView.
-        - IfNeeded : ODScrollView only adjusts the UITextInput if it overlaps with the shown keyboard.
-     */
+    
+    ///
+    /// There 2 types of adjustment option: Always and IfNeeded
+    ///
+    /// - always : ODScrollView always adjusts the UITextInput which is placed anywhere in the ODScrollView.
+    /// - ifNeeded : ODScrollView only adjusts the UITextInput if it overlaps with the shown keyboard.
+    ///
+    /// - Parameter scrollView: TODO
     func adjustmentOption(for scrollView: ODScrollView) -> AdjustmentOption
-    
+
+
     // MARK: - Hiding Keyboard Settings
-    
-    /**
-     Provides a view for tap gesture that hides keyboard.
-     
-     By default, keyboard can be dismissed by keyboardDismissMode of UIScrollView.
-     
-         keyboardDismissMode = .none
-         keyboardDismissMode = .onDrag
-         keyboardDismissMode = .interactive
-     
-     Beside above settings:
-     
-     - Returning UIView from this, lets you to hide the keyboard by tapping the UIView you provide, and also be able to use isResettingAdjustmentEnabled(for scrollView: ODScrollView) setting.
-     
-     - If you return nil instead of UIView object, It means that hiding the keyboard by tapping is disabled.
-     */
+
+    ///
+    /// Provides a view for tap gesture that hides keyboard.
+    ///
+    /// By default, keyboard can be dismissed by keyboardDismissMode of UIScrollView.
+    ///
+    ///```
+    ///    keyboardDismissMode = .none
+    ///    keyboardDismissMode = .onDrag
+    ///    keyboardDismissMode = .interactive
+    ///```
+    /// Beside above settings:
+    ///
+    /// - Returning UIView from this, lets you to hide the keyboard by tapping the UIView you provide, and also be able to use isResettingAdjustmentEnabled(for scrollView: ODScrollView) setting.
+    ///
+    /// - If you return nil instead of UIView object, It means that hiding the keyboard by tapping is disabled.
+    ///
+    /// - Parameter scrollView: TODO
     func hideKeyboardByTappingToView(for scrollView: ODScrollView) -> UIView?
-    
-    /**
-      Resets the scroll view offset - which is adjusted before - to beginning its position after keyboard hid by tapping to the provided UIView via hideKeyboardByTappingToView.
-     
-     ## IMPORTANT:
-     This feature requires a UIView that is provided by hideKeyboardByTappingToView().
-     */
+
+
+    /// Resets the scroll view offset - which is adjusted before - to beginning its position after keyboard hid by tapping to the provided UIView via hideKeyboardByTappingToView.
+    ///
+    /// ## IMPORTANT:
+    /// This feature requires a UIView that is provided by hideKeyboardByTappingToView().
+    ///
+    /// - Parameter scrollView: TODO
     func isResettingAdjustmentEnabled(for scrollView: ODScrollView) -> Bool
     
 }

--- a/ODScrollView/Classes/ODScrollViewOptions.swift
+++ b/ODScrollView/Classes/ODScrollViewOptions.swift
@@ -12,8 +12,8 @@ import UIKit
 struct ODScrollViewOptions {
     static var adjustmentMargin: CGFloat = 0
     static var adjustmentEnabled: Bool = true
-    static var adjustmentOption: AdjustmentOption = .Always
-    static var adjustmentDirection: AdjustmentDirection = .Bottom
+    static var adjustmentOption: AdjustmentOption = .always
+    static var adjustmentDirection: AdjustmentDirection = .bottom
     static var hideKeyboardByTappingToView: UIView?
     static var isResettingAdjustmentEnabled: Bool = false
 }

--- a/ODScrollView/Classes/ODScrollViewRenderer.swift
+++ b/ODScrollView/Classes/ODScrollViewRenderer.swift
@@ -43,7 +43,10 @@ final class ODScrollViewRenderer {
         
         // Prepare variables
 
-        guard let scrollView = scrollView else { return }
+        guard
+            let scrollView = scrollView,
+            let scrollViewMinYGlobal = scrollView.superview?.convert(scrollView.frame, to: nil).minY
+        else { return }
 
         if isKeyboardHidden { // You can set another UITextInputs as firstResponder without hiding keyboard. This lets you to reset its very first position
             beforeAdjustmentContentOffsetY = scrollView.contentOffset.y // store it to reset
@@ -51,7 +54,6 @@ final class ODScrollViewRenderer {
         
         var totalContentOffset = scrollView.contentOffset.y
 
-        guard let scrollViewMinYGlobal = scrollView.superview?.convert(scrollView.frame, to: nil).minY else { return }
         let scrollViewMaxYGlobal = scrollViewMinYGlobal + scrollView.frame.height
         let keyboardMinYGlobal = UIScreen.main.bounds.height - keyboardHeight
         let isScrollViewAndKeyboardOverlapping = ODScrollViewAdjustmentCalculator.isScrollViewAndKeyboardOverlapping(keyboardMinYGlobal: keyboardMinYGlobal, scrollViewMaxYGlobal: scrollViewMaxYGlobal)

--- a/ODScrollView/Classes/ODScrollViewRenderer.swift
+++ b/ODScrollView/Classes/ODScrollViewRenderer.swift
@@ -10,8 +10,9 @@ import Foundation
 import UIKit
 
 final class ODScrollViewRenderer {
-    
-    private var beforeAdjustmentContentOffsetY: CGFloat = 0 // It's using for resetting the adjusted view.
+
+    /// It's using for resetting the adjusted view.
+    private var beforeAdjustmentContentOffsetY: CGFloat = 0
     private var keyboardHeight: CGFloat = 0
 
     private weak var scrollView: ODScrollView?
@@ -151,8 +152,10 @@ final class ODScrollViewRenderer {
     
     private func adjustView(to offset: CGFloat) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            guard let scrollView = self.scrollView else { return }
+            guard
+                let self = self,
+                let scrollView = self.scrollView
+            else { return }
             
             scrollView.setContentOffset(CGPoint(x: 0, y: offset), animated: true)
         }

--- a/ODScrollView/Classes/Optional+Extensions.swift
+++ b/ODScrollView/Classes/Optional+Extensions.swift
@@ -19,6 +19,6 @@ postfix operator ^!=?
 extension Optional {
 
     static postfix func ^!=?(_ optional: Optional) -> Bool {
-        return (optional == nil) ? false : true
+        (optional == nil) ? false : true
     }
 }

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ extension ViewController: ODScrollViewDelegate {
     //  Specifies adjustment direction for each UITextInput. It means that  some of UITextInputs inside ODScrollView can be adjusted to the bottom, while others can be adjusted to center or top.
     func adjustmentDirection(selected textInput: UITextInput, inside scrollView: ODScrollView) -> AdjustmentDirection {
         if let textField = textInput as? UITextField, textField == self.UITextField_inside_contentView {
-            return .Bottom
+            return .bottom
         } else {
-            return .Center
+            return .center
         }
     }
 
@@ -236,7 +236,7 @@ This feature is not going to work unless textView is subView of _ODScrollView
 */
 func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         _ODScrollView.trackTextInputCursor(for textView)
-        return true
+    return true
 }
 ```
 


### PR DESCRIPTION
I've added changed how you documented the functions, take a look at that. But I think this way is better and more used. But it's your decision.

I also tried refactor `guard let` to below version by combining them.-> 
```
guard 
   let ... = ... ,
   let ... = ... 
else { return }
```
Some Swift 5.1 refactorings. 
And lastly few extensions.

Great work, I think there might be some still improvement. I just wanted to head in for a coding style refactor and understand what it really does. Let's check it again for **real** future improvements

👍 